### PR TITLE
Allow indentation width to be set explicitly

### DIFF
--- a/Tests/MacroTestingTests/IndentationWidthTests.swift
+++ b/Tests/MacroTestingTests/IndentationWidthTests.swift
@@ -1,0 +1,116 @@
+import MacroTesting
+import SwiftSyntax
+import SwiftSyntaxMacros
+import XCTest
+
+private struct AddMemberMacro: MemberMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["let v: T"]
+  }
+}
+
+final class IndentationWidthTests: XCTestCase {
+  func testExpansionAddsMemberUsingDetectedIndentation() {
+    assertMacro([AddMemberMacro.self]) {
+      """
+      @AddMember
+      struct S {
+        let w: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let w: T
+
+        let v: T
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsMemberToEmptyStructUsingDefaultIndentation() {
+    assertMacro([AddMemberMacro.self]) {
+      """
+      @AddMember
+      struct S {
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+
+          let v: T
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsMemberToEmptyStructUsingTwoSpaceIndentation() {
+    assertMacro(
+      [AddMemberMacro.self],
+      indentationWidth: .spaces(2)
+    ) {
+      """
+      @AddMember
+      struct S {
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+
+        let v: T
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsMemberToEmptyStructUsingTwoSpaceIndentation_withMacroTesting() {
+    withMacroTesting(
+      indentationWidth: .spaces(2),
+      macros: [AddMemberMacro.self]
+    ) {
+      assertMacro {
+        """
+        @AddMember
+        struct S {
+        }
+        """
+      } expansion: {
+        """
+        struct S {
+
+          let v: T
+        }
+        """
+      }
+    }
+  }
+
+  func testExpansionAddsMemberUsingMistchedIndentation() {
+    assertMacro(
+      [AddMemberMacro.self],
+      indentationWidth: .spaces(4)
+    ) {
+      """
+      @AddMember
+      struct S {
+        let w: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let w: T
+
+          let v: T
+      }
+      """
+    }
+  }
+}


### PR DESCRIPTION
This allows the user to circumvent the default indentation behavior. In particular, it can be used to avoid getting the default four-space indentation when expanding source that doesn’t contain any indentation to infer the indentation width from, e.g.:

```swift
@AddMember
struct S {
}
```

Unindented original source seems uncommon, but it occurs pretty frequently in my macro tests. For example, I have a collection of tests that exercise each possible combination of access modifier for structs, classes, and actors.

Changes:

* The `assertMacro` and `withMacroTesting` functions now accept `indentationWidth` as a parameter (`Trivia`).
* Introduces `IndentationWidthTests` to validate both the existing indentation behavior and the new explicit indentation width functionality.

Some alternatives to consider:

* Instead offer `defaultIndentationWidth` to let the user only control the fallback indentation value. This would work in my use case.
* Only support explicit indentation width in `assertMacro` and not in `withMacroTesting`.