### PR TITLE
Fix application of fix-its replacing parent instead of first child

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "4862d48562483d274a2ac7522d905c9237a31a48",
-        "version" : "1.15.0"
+        "revision" : "59b663f68e69f27a87b45de48cb63264b8194605",
+        "version" : "1.15.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     }
   ],

--- a/Sources/MacroTesting/SwiftSyntax/SourceEdit.swift
+++ b/Sources/MacroTesting/SwiftSyntax/SourceEdit.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// A textual edit to the original source represented by a range and a
+/// replacement.
+public struct SourceEdit: Equatable {
+  /// The half-open range that this edit applies to.
+  public let range: Range<AbsolutePosition>
+  /// The text to replace the original range with. Empty for a deletion.
+  public let replacement: String
+
+  /// Length of the original source range that this edit applies to. Zero if
+  /// this is an addition.
+  public var length: SourceLength {
+    return SourceLength(utf8Length: range.lowerBound.utf8Offset - range.upperBound.utf8Offset)
+  }
+
+  /// Create an edit to replace `range` in the original source with
+  /// `replacement`.
+  public init(range: Range<AbsolutePosition>, replacement: String) {
+    self.range = range
+    self.replacement = replacement
+  }
+
+  /// Convenience function to create a textual addition after the given node
+  /// and its trivia.
+  public static func insert(_ newText: String, after node: some SyntaxProtocol) -> SourceEdit {
+    return SourceEdit(range: node.endPosition..<node.endPosition, replacement: newText)
+  }
+
+  /// Convenience function to create a textual addition before the given node
+  /// and its trivia.
+  public static func insert(_ newText: String, before node: some SyntaxProtocol) -> SourceEdit {
+    return SourceEdit(range: node.position..<node.position, replacement: newText)
+  }
+
+  /// Convenience function to create a textual replacement of the given node,
+  /// including its trivia.
+  public static func replace(_ node: some SyntaxProtocol, with replacement: String) -> SourceEdit {
+    return SourceEdit(range: node.position..<node.endPosition, replacement: replacement)
+  }
+
+  /// Convenience function to create a textual deletion the given node and its
+  /// trivia.
+  public static func remove(_ node: some SyntaxProtocol) -> SourceEdit {
+    return SourceEdit(range: node.position..<node.endPosition, replacement: "")
+  }
+}
+
+extension SourceEdit: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    let hasNewline = replacement.contains { $0.isNewline }
+    if hasNewline {
+      return #"""
+        \#(range.lowerBound.utf8Offset)-\#(range.upperBound.utf8Offset)
+        """
+        \#(replacement)
+        """
+        """#
+    }
+    return "\(range.lowerBound.utf8Offset)-\(range.upperBound.utf8Offset) \"\(replacement)\""
+  }
+}

--- a/Sources/MacroTesting/_SwiftSyntaxTestSupport/FixItApplier.swift
+++ b/Sources/MacroTesting/_SwiftSyntaxTestSupport/FixItApplier.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+
+public enum FixItApplier {
+  /// Applies selected or all Fix-Its from the provided diagnostics to a given syntax tree.
+  ///
+  /// - Parameters:
+  ///   - diagnostics: An array of `Diagnostic` objects, each containing one or more Fix-Its.
+  ///   - filterByMessages: An optional array of message strings to filter which Fix-Its to apply.
+  ///     If `nil`, the first Fix-It from each diagnostic is applied.
+  ///   - tree: The syntax tree to which the Fix-Its will be applied.
+  ///
+  /// - Returns: A `String` representation of the modified syntax tree after applying the Fix-Its.
+  //  public static func applyFixes(
+  //    from diagnostics: [Diagnostic],
+  //    filterByMessages messages: [String]?,
+  //    to tree: any SyntaxProtocol
+  //  ) -> String {
+  //    let messages = messages ?? diagnostics.compactMap { $0.fixIts.first?.message.message }
+  //
+  //    let edits =
+  //      diagnostics
+  //      .flatMap(\.fixIts)
+  //      .filter { messages.contains($0.message.message) }
+  //      .flatMap(\.edits)
+  //
+  //    return self.apply(edits: edits, to: tree)
+  //  }
+
+  /// Apply the given edits to the syntax tree.
+  ///
+  /// - Parameters:
+  ///   - edits: The edits to apply to the syntax tree
+  ///   - tree: he syntax tree to which the edits should be applied.
+  /// - Returns: A `String` representation of the modified syntax tree after applying the edits.
+  public static func apply(
+    edits: [SourceEdit],
+    to tree: any SyntaxProtocol
+  ) -> String {
+    var edits = edits
+    var source = tree.description
+
+    while let edit = edits.first {
+      edits = Array(edits.dropFirst())
+
+      let startIndex = source.utf8.index(source.utf8.startIndex, offsetBy: edit.startUtf8Offset)
+      let endIndex = source.utf8.index(source.utf8.startIndex, offsetBy: edit.endUtf8Offset)
+
+      source.replaceSubrange(startIndex..<endIndex, with: edit.replacement)
+
+      edits = edits.compactMap { remainingEdit -> SourceEdit? in
+        if remainingEdit.replacementRange.overlaps(edit.replacementRange) {
+          // The edit overlaps with the previous edit. We can't apply both
+          // without conflicts. Apply the one that's listed first and drop the
+          // later edit.
+          return nil
+        }
+
+        // If the remaining edit starts after or at the end of the edit that we just applied,
+        // shift it by the current edit's difference in length.
+        if edit.endUtf8Offset <= remainingEdit.startUtf8Offset {
+          let startPosition = AbsolutePosition(
+            utf8Offset: remainingEdit.startUtf8Offset - edit.replacementRange.count
+              + edit.replacementLength)
+          let endPosition = AbsolutePosition(
+            utf8Offset: remainingEdit.endUtf8Offset - edit.replacementRange.count
+              + edit.replacementLength)
+          return SourceEdit(
+            range: startPosition..<endPosition, replacement: remainingEdit.replacement)
+        }
+
+        return remainingEdit
+      }
+    }
+
+    return source
+  }
+}
+
+extension SourceEdit {
+  fileprivate var startUtf8Offset: Int {
+    return range.lowerBound.utf8Offset
+  }
+
+  fileprivate var endUtf8Offset: Int {
+    return range.upperBound.utf8Offset
+  }
+
+  fileprivate var replacementLength: Int {
+    return replacement.utf8.count
+  }
+
+  fileprivate var replacementRange: Range<Int> {
+    return startUtf8Offset..<endUtf8Offset
+  }
+}

--- a/Tests/MacroTestingTests/FixItTests.swift
+++ b/Tests/MacroTestingTests/FixItTests.swift
@@ -1,0 +1,92 @@
+import MacroTesting
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import XCTest
+
+private enum ReplaceFirstMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard
+      let nodeToReplace = declaration.memberBlock.members.first,
+      let newNode = try? MemberBlockItemSyntax(
+        decl: VariableDeclSyntax(SyntaxNodeString(stringLiteral: "\n  let oye: Oye"))
+      )
+    else { return [] }
+
+    context.diagnose(
+      Diagnostic(
+        node: node.attributeName,
+        message: SimpleDiagnosticMessage(
+          message: "First member needs to be replaced",
+          diagnosticID: MessageID(domain: "domain", id: "diagnostic2"),
+          severity: .warning
+        ),
+        fixIts: [
+          FixIt(
+            message: SimpleDiagnosticMessage(
+              message: "Replace the first member",
+              diagnosticID: MessageID(domain: "domain", id: "fixit1"),
+              severity: .error
+            ),
+            changes: [
+              .replace(oldNode: Syntax(nodeToReplace), newNode: Syntax(newNode))
+            ]
+          )
+        ]
+      )
+    )
+
+    return []
+  }
+}
+
+final class FixItTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [ReplaceFirstMemberMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testReplaceFirstMember_IncorrectlyReplacesParent() {
+    assertMacro {
+      """
+      @ReplaceFirstMember
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+        let baz: Baz
+      }
+      """
+    } diagnostics: {
+      """
+      @ReplaceFirstMember
+       ┬─────────────────
+       ╰─ ⚠️ First member needs to be replaced
+          ✏️ Replace the first member
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+        let baz: Baz
+      }
+      """
+    } fixes: {
+      """
+      @ReplaceFirstMember
+      struct FooBar {
+        let oye: Oye
+      }
+      """
+    } expansion: {
+      """
+      struct FooBar {
+        let oye: Oye
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/FixItTests.swift
+++ b/Tests/MacroTestingTests/FixItTests.swift
@@ -52,7 +52,7 @@ final class FixItTests: BaseTestCase {
     }
   }
 
-  func testReplaceFirstMember_IncorrectlyReplacesParent() {
+  func testReplaceFirstMember() {
     assertMacro {
       """
       @ReplaceFirstMember
@@ -79,12 +79,16 @@ final class FixItTests: BaseTestCase {
       @ReplaceFirstMember
       struct FooBar {
         let oye: Oye
+        let bar: Bar
+        let baz: Baz
       }
       """
     } expansion: {
       """
       struct FooBar {
         let oye: Oye
+        let bar: Bar
+        let baz: Baz
       }
       """
     }


### PR DESCRIPTION
This fixes #15 by pulling in the latest `FixItApplier` from swift-syntax `main` (d647052), which is now String-based.

* For review, I left an intermediate commit showing how the new test fails before the fix. I’m happy to squash that commit into the fix before merging.
* I added “Bump deps” opportunistically, but this PR doesn’t depend on it. Let me know if you’d rather do that outside of this PR.

Note:
* The upstream [`FixItApplier`](https://github.com/apple/swift-syntax/blob/d647052/Sources/_SwiftSyntaxTestSupport/FixItApplier.swift) has undergone a complete rework in swift-syntax `main`. It’s now `String`-based rather than `SyntaxRewriter`-based. (It’s publicly accessible but not exposed as a product within the underscored `_SwiftSyntaxTestSupport` module, an “internal helper target”.)
* The upstream `FixItApplier.applyFixes` function isn’t needed by swift-macro-testing, and omitting it allows [these two extensions on `FixIt`](https://github.com/apple/swift-syntax/blob/d647052/Sources/SwiftDiagnostics/FixIt.swift#L50) to be omitted.
* `SwiftSyntax/SourceEdit` is public but hasn't been released, so eventually it can be removed from swift-macro-testing.