### PR TITLE
Improved recording by leveraging inline snapshot removal

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "5b0c434778f2c1a4c9b5ebdb8682b28e84dd69bd",
-        "version" : "1.15.4"
+        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
+        "version" : "1.16.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.0"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "inline-snapshot-removal"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "inline-snapshot-removal"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.16.0"),
   ],
   targets: [
     .target(

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -235,13 +235,21 @@ public func assertMacro(
       )
     } else if diagnosedSource != nil {
       offset += 1
-      InlineSnapshotSyntaxDescriptor(
-        trailingClosureLabel: "diagnostics",
-        trailingClosureOffset: offset
-      )
-      .fail(
-        "Expected diagnostics, but there were none",
+      assertInlineSnapshot(
+        of: nil,
+        as: ._lines,
+        message: """
+          Diagnostic output (\(newPrefix)) differed from expected output (\(oldPrefix)). \
+          Difference: …
+          """,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          deprecatedTrailingClosureLabels: ["matches"],
+          trailingClosureLabel: "diagnostics",
+          trailingClosureOffset: offset
+        ),
+        matches: diagnosedSource,
         file: file,
+        function: function,
         line: line,
         column: column
       )
@@ -299,13 +307,20 @@ public func assertMacro(
       )
     } else if fixedSource != nil {
       offset += 1
-      InlineSnapshotSyntaxDescriptor(
-        trailingClosureLabel: "fixes",
-        trailingClosureOffset: offset
-      )
-      .fail(
-        "Expected fix-its, but there were none",
+      assertInlineSnapshot(
+        of: nil,
+        as: ._lines,
+        message: """
+          Fixed output (\(newPrefix)) differed from expected output (\(oldPrefix)). \
+          Difference: …
+          """,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          trailingClosureLabel: "fixes",
+          trailingClosureOffset: offset
+        ),
+        matches: fixedSource,
         file: file,
+        function: function,
         line: line,
         column: column
       )
@@ -333,13 +348,21 @@ public func assertMacro(
       )
     } else if expandedSource != nil {
       offset += 1
-      InlineSnapshotSyntaxDescriptor(
-        trailingClosureLabel: "expansion",
-        trailingClosureOffset: offset
-      )
-      .fail(
-        "Expected macro expansion, but there was none",
+      assertInlineSnapshot(
+        of: nil,
+        as: ._lines,
+        message: """
+          Expanded output (\(newPrefix)) differed from expected output (\(oldPrefix)). \
+          Difference: …
+          """,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          deprecatedTrailingClosureLabels: ["matches"],
+          trailingClosureLabel: "expansion",
+          trailingClosureOffset: offset
+        ),
+        matches: expandedSource,
         file: file,
+        function: function,
         line: line,
         column: column
       )


### PR DESCRIPTION
This uses the new functionality of swift-snapshot-testing 1.16.0 to automatically remove stale inline snapshots when recording over a snapshot that used different closure names.