### PR TITLE
Support swift-syntax from 600.0.0-latest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "08a2f0a9a30e0f705f79c9cfaca1f68b71bdc775",
-        "version" : "510.0.0"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
+        "version" : "1.16.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.16.0"),
   ],
   targets: [

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -177,11 +177,19 @@ public func assertMacro(
         origSourceFile: .init(moduleName: "TestModule", fullFilePath: "Test.swift")
       ]
     )
-    var expandedSourceFile = origSourceFile.expand(
-      macros: macros,
-      in: context,
-      indentationWidth: indentationWidth
-    )
+    #if canImport(SwiftSyntax600)
+      var expandedSourceFile = origSourceFile.expand(
+        macros: macros,
+        contextGenerator: { _ in context },
+        indentationWidth: indentationWidth
+      )
+    #else
+      var expandedSourceFile = origSourceFile.expand(
+        macros: macros,
+        in: context,
+        indentationWidth: indentationWidth
+      )
+    #endif
 
     var offset = 0
 
@@ -300,11 +308,19 @@ public func assertMacro(
           fixedSourceFile: .init(moduleName: "TestModule", fullFilePath: "Test.swift")
         ]
       )
-      expandedSourceFile = fixedSourceFile.expand(
-        macros: macros,
-        in: context,
-        indentationWidth: indentationWidth
-      )
+      #if canImport(SwiftSyntax600)
+        expandedSourceFile = fixedSourceFile.expand(
+          macros: macros,
+          contextGenerator: { _ in context },
+          indentationWidth: indentationWidth
+        )
+      #else
+        expandedSourceFile = fixedSourceFile.expand(
+          macros: macros,
+          in: context,
+          indentationWidth: indentationWidth
+        )
+      #endif
     } else if fixedSource != nil {
       offset += 1
       assertInlineSnapshot(


### PR DESCRIPTION
The Xcode 16 beta generates macro projects using these swift-syntax snapshots. Luckily things seem to be backwards compatible, so we can expand our supported range.