### PR TITLE
Fix resolution of SwiftSyntax 600

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..."600.0.0-prerelease"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.16.0"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..."600.0.0-prerelease"),
+    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.16.0"),
   ],
   targets: [


### PR DESCRIPTION
When using swift-macro-testing in a package that depends on SwiftSyntax `600.0.0-prerelease` (or `600.0.0-latest`), SwiftPM appears to be unable to reconcile the `"509.0.0"..<"601.0.0"` range with the `600.0.0-prerelease` requirement from the dependent package.

From my experience, it seems that SwiftPM doesn't like to resolve prerelease versions (`x.y.z-a`) when supplied with a broader range. Providing the prerelease as an explicit upper bound fixes this. ~~Not 100% sure this is a reliable approach, but it seems to fix the issue from my experience.~~ Looks like this is [intentional](https://github.com/apple/swift-tools-support-core/blob/b170d46b94d6c1cd91db97d2e3a1e0bdb5b79a24/Sources/TSCUtility/Version.swift#L347-L360) and including `-prerelease` in the range specifier is a kosher fix.

Related:
- https://github.com/apple/swift-package-manager/issues/7083
- https://github.com/apple/swift-package-manager/issues/7316

[Slack discussion](https://pointfreecommunity.slack.com/archives/C05SMQUBGVB/p1719179691655419)