### PR TITLE
Xcode 16 beta 5: Fix test trait

### DIFF
--- a/.swiftpm/configuration/Package.resolved
+++ b/.swiftpm/configuration/Package.resolved
@@ -5,14 +5,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "63d3b45dd249878a41c56274a748ca2c1c9c5230",
-        "version" : "1.17.1"
+        "branch" : "fix-test-trait",
+        "revision" : "cf0742603c2aabb3226fc4f1e1dfb92add3e9ddf"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"

--- a/.swiftpm/configuration/Package.resolved
+++ b/.swiftpm/configuration/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "branch" : "fix-test-trait",
-        "revision" : "cf0742603c2aabb3226fc4f1e1dfb92add3e9ddf"
+        "revision" : "6d932a79e7173b275b96c600c86c603cf84f153c",
+        "version" : "1.17.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.1"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "fix-test-trait"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", branch: "fix-test-trait"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.4"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -9,6 +9,10 @@ import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import XCTest
 
+#if canImport(Testing)
+  import Testing
+#endif
+
 /// Asserts that a given Swift source string matches an expected string with all macros expanded.
 ///
 /// To write a macro assertion, you simply pass the mapping of macros to expand along with the
@@ -124,7 +128,12 @@ public func assertMacro(
   line: UInt = #line,
   column: UInt = #column
 ) {
-  withSnapshotTesting(record: record ?? SnapshotTestingConfiguration.current?.record) {
+  #if canImport(Testing)
+    let record = record ?? SnapshotTestingConfiguration.current?.record ?? Test.current?.record
+  #else
+    let record = record ?? SnapshotTestingConfiguration.current?.record
+  #endif
+  withSnapshotTesting(record: record) {
     let macros = macros ?? MacroTestingConfiguration.current.macros
     guard let macros, !macros.isEmpty else {
       recordIssue(


### PR DESCRIPTION
We can't yet leverage custom execution traits, and in fact Xcode 16 beta 5 removed access to them. Instead we can use the task's current test to access trait information directly from our helpers.