### PR TITLE
Xcode 16 beta 5: look up macros from current test trait

### DIFF
--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -134,7 +134,11 @@ public func assertMacro(
     let record = record ?? SnapshotTestingConfiguration.current?.record
   #endif
   withSnapshotTesting(record: record) {
-    let macros = macros ?? MacroTestingConfiguration.current.macros
+    #if canImport(Testing)
+      let macros = macros ?? MacroTestingConfiguration.current.macros ?? Test.current?.macros
+    #else
+      let macros = macros ?? MacroTestingConfiguration.current.macros
+    #endif
     guard let macros, !macros.isEmpty else {
       recordIssue(
         """


### PR DESCRIPTION
I was trying out the experimental swift testing support and was getting errors that I had not configured any macros for testing. Traced it back to the `assertMacro` function not falling back to `Test.current?.macros`.