### PR TITLE
Add support for lexical context

### DIFF
--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -203,7 +203,9 @@ public func assertMacro(
       #if canImport(SwiftSyntax600)
         var expandedSourceFile = origSourceFile.expand(
           macros: macros,
-          contextGenerator: { _ in context },
+          contextGenerator: { syntax in
+            BasicMacroExpansionContext(sharingWith: context, lexicalContext: syntax.allMacroLexicalContexts())
+          },
           indentationWidth: indentationWidth
         )
       #else

--- a/Tests/MacroTestingTests/EntryMacroTests.swift
+++ b/Tests/MacroTestingTests/EntryMacroTests.swift
@@ -1,0 +1,52 @@
+import MacroTesting
+import XCTest
+
+final class EntryMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      macros: [
+        EntryMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testWithinEnvironmentValues() {
+    assertMacro {
+      """
+      extension EnvironmentValues {
+        @Entry var x: String = ""
+      }
+      """
+    } expansion: {
+      """
+      extension EnvironmentValues {
+        var x: String {
+          get {
+            fatalError()
+          }
+        }
+      }
+      """
+    }
+  }
+
+  func testNotWithinEnvironmentValues() {
+    assertMacro {
+      """
+      extension String {
+        @Entry var x: String = ""
+      }
+      """
+    } diagnostics: {
+      """
+      extension String {
+        @Entry var x: String = ""
+        ┬─────
+        ╰─ 🛑 '@Entry' macro can only attach to var declarations inside extensions of EnvironmentValues
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/EntryMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/EntryMacro.swift
@@ -1,0 +1,25 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+// Not complete, just enough to unit test lexical context.
+public struct EntryMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    let isInEnvironmentValues = context.lexicalContext.contains { lexicalContext in
+      lexicalContext.as(ExtensionDeclSyntax.self)?.extendedType.trimmedDescription == "EnvironmentValues"
+    }
+
+    guard isInEnvironmentValues else {
+      throw MacroExpansionErrorMessage("'@Entry' macro can only attach to var declarations inside extensions of EnvironmentValues")
+    }
+
+    return [
+      AccessorDeclSyntax(accessorSpecifier: .keyword(.get)) {
+        "fatalError()"
+      },
+    ]
+  }
+}


### PR DESCRIPTION
Lexical context was not being supplied within the `assertMacro` function. Thanks to a nudge from @stephencelis I took a peek at Apple's testing tools and found [this](https://github.com/swiftlang/swift-syntax/blob/c2c798059a3787694d1fd22668d55d09d725c101/Sources/SwiftSyntaxMacrosGenericTestSupport/Assertions.swift#L515) which works here!

For tests I added a just-enough-functionality version of the `@Entry` macro to test lexical contexts appropriately. Happy to change this though!