### PR TITLE
Remove @_implementationOnly imports.

### DIFF
--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -10,9 +10,7 @@ import SwiftSyntaxMacros
 import XCTest
 
 #if canImport(Testing)
-  // NB: We are importing only the implementation of Testing because that framework is not available
-  //     in Xcode UI test targets.
-  @_implementationOnly import Testing
+  import Testing
 #endif
 
 /// Asserts that a given Swift source string matches an expected string with all macros expanded.

--- a/Sources/MacroTesting/Internal/RecordIssue.swift
+++ b/Sources/MacroTesting/Internal/RecordIssue.swift
@@ -1,9 +1,7 @@
 import XCTest
 
 #if canImport(Testing)
-  // NB: We are importing only the implementation of Testing because that framework is not available
-  //     in Xcode UI test targets.
-  @_implementationOnly import Testing
+  import Testing
 #endif
 
 @_spi(Internals)

--- a/Sources/MacroTesting/MacrosTestTrait.swift
+++ b/Sources/MacroTesting/MacrosTestTrait.swift
@@ -2,9 +2,7 @@
   import SnapshotTesting
   import SwiftSyntax
   import SwiftSyntaxMacros
-  // NB: We are importing only the implementation of Testing because that framework is not available
-  //     in Xcode UI test targets.
-  @_implementationOnly import Testing
+  import Testing
 
   @_spi(Experimental)
   extension Trait where Self == _MacrosTestTrait {


### PR DESCRIPTION
We preemptively added `@_implementationOnly import`s to work around an Xcode problem, but it turns out that problem only arises in UI test targets. And as far as we know, there is no legitimate reason to import this library into a UI testing target. So let's not keep these around.