### PR TITLE
Fixed misplaced comma in Integration with Swift Testing example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ import MacroTesting
 
 @Suite(
   .macros(
-    record: .missing // Record only missing snapshots
-    macros: ["stringify": StringifyMacro.self],
+    record: .missing, // Record only missing snapshots
+    macros: ["stringify": StringifyMacro.self]
   )
 )
 struct StringifyMacroSwiftTestingTests {

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ import MacroTesting
 
 @Suite(
   .macros(
-    record: .missing, // Record only missing snapshots
-    macros: ["stringify": StringifyMacro.self]
+    ["stringify": StringifyMacro.self],
+    record: .missing // Record only missing snapshots
   )
 )
 struct StringifyMacroSwiftTestingTests {


### PR DESCRIPTION
The `record` parameter is missing a comma, and `macros` has one it doesn't need.

This PR fixes this issue so users can copy/paste the code sample and have it compile.