### PR TITLE
Fixes for SwiftSyntax 601

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ concurrency:
 jobs:
   macos:
     name: macOS
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
       - name: Run tests
         run: swift test
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "4d23a799723a52d43100a64649bc07b777ae81b73a2353d64b05f800e4dc1ee6",
   "pins" : [
     {
       "identity" : "swift-custom-dump",
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "f5bfff796ee8e3bc9a685b7ffba1bf20663eb370",
-        "version" : "1.18.0"
+        "revision" : "1be8144023c367c5de701a6313ed29a3a10bf59b",
+        "version" : "1.18.3"
       }
     },
     {
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
+        "revision" : "1103c45ece4f7fe160b8f75b4ea1ee2e5fac1841",
+        "version" : "601.0.0"
       }
     },
     {
@@ -32,10 +33,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "1103c45ece4f7fe160b8f75b4ea1ee2e5fac1841",
-        "version" : "601.0.0"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -472,7 +472,7 @@ extension FixIt.Change {
       )
 
     #if canImport(SwiftSyntax601)
-      case .replaceChild(let data):
+      case .replaceChild(let replacingChildData):
         let range = replacingChildData.replacementRange
         let start = expansionContext.position(
           of: range.lowerBound,

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -470,6 +470,23 @@ extension FixIt.Change {
         range: start..<end,
         replacement: newTrivia.description
       )
+
+    #if canImport(SwiftSyntax601)
+      case .replaceChild(let data):
+        let range = replacingChildData.replacementRange
+        let start = expansionContext.position(
+          of: range.lowerBound,
+          anchoredAt: replacingChildData.parent
+        )
+        let end = expansionContext.position(
+          of: range.upperBound,
+          anchoredAt: replacingChildData.parent
+        )
+        return SourceEdit(
+          range: start..<end,
+          replacement: replacingChildData.newChild.description
+        )
+    #endif
     }
   }
 }

--- a/Tests/MacroTestingTests/MacroExamples/OptionSetMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/OptionSetMacro.swift
@@ -93,7 +93,9 @@ public struct OptionSetMacro {
       else {
         context.diagnose(
           OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel).diagnose(
-            at: optionEnumNameArg.expression))
+            at: optionEnumNameArg.expression
+          )
+        )
         return nil
       }
 
@@ -121,7 +123,8 @@ public struct OptionSetMacro {
       }).first
     else {
       context.diagnose(
-        OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl))
+        OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl)
+      )
       return nil
     }
 
@@ -135,7 +138,25 @@ public struct OptionSetMacro {
       return nil
     }
 
-    return (structDecl, optionsEnum, rawType)
+    let rawTypeSyntax: TypeSyntax?
+    #if canImport(SwiftSyntax601)
+      switch rawType {
+      case .type(let typeSyntax):
+        rawTypeSyntax = typeSyntax
+      default:
+        rawTypeSyntax = nil
+      }
+    #else
+      rawTypeSyntax = rawType
+    #endif
+
+    guard let rawTypeSyntax
+    else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute))
+      return nil
+    }
+
+    return (structDecl, optionsEnum, rawTypeSyntax)
   }
 }
 


### PR DESCRIPTION
SwiftSyntax 601 has some breaking changes from SwiftSyntax 600 that affected this library and so we need to do a little work to support all versions of SwiftSyntax.