### PR TITLE
Avoid concurrency errors

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -39,5 +39,5 @@ let package = Package(
       ]
     ),
   ],
-  swiftLanguageModes: [.v6]
+  swiftLanguageModes: [.v5]
 )


### PR DESCRIPTION
In certain situations, the Swift 5 mode of Snapshot Testing is clashing with this project's Swift 6 mode. I encountered this in a Linux project the other day, but am unable to reproduce it today. Still, this change fixed it, and until Snapshot Testing is `v6`-compliant the safest thing is probably for downstream clients to have matching modes.