### PR TITLE
[chore] update swift-snapshot-testing to 1.18.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.0"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.3"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
   ],
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.4"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.3"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
   ],
   targets: [


### PR DESCRIPTION
## Motivation

I want to update swift-syntax by updating swift-snapshot-testing.

- swift-syntax
  - Package.swift
    - Versions less than 601.0.0 are available ([Package.swift#swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing/blob/1.18.0/Package.swift#L29))
  - Package@swift-6.0.swift
    - Versions less than 601.0.0-prerelease are available ([Package.swift#swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing/blob/1.17.4/Package.swift#L24))

## Issues
- None.