### PR TITLE
Make MacroTestingConfiguration Sendable

### DIFF
--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -767,7 +767,7 @@ internal func macroName(className: String, isExpression: Bool) -> String {
   return name
 }
 
-struct MacroTestingConfiguration {
+struct MacroTestingConfiguration: Sendable {
   @TaskLocal static var current = Self()
 
   var indentationWidth: Trivia? = nil


### PR DESCRIPTION
In my package for 5.10, with Xcode 16.2 I was getting that, so why not sendablize it?

```
.../SourcePackages/checkouts/swift-macro-testing/Sources/MacroTesting/MacrosTestTrait.swift:11:9: error: stored property 'configuration' of 'Sendable'-conforming struct '_MacrosTestTrait' has non-sendable type 'MacroTestingConfiguration'
    let configuration: MacroTestingConfiguration
        ^
.../SourcePackages/checkouts/swift-macro-testing/Sources/MacroTesting/AssertMacro.swift:770:8: note: consider making struct 'MacroTestingConfiguration' conform to the 'Sendable' protocol
struct MacroTestingConfiguration {
       ^
                                 : Sendable
```