### PR TITLE
Support swift-syntax 605

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.4"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
     .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Bumps swift-syntax upper bound from 603 to 605 to support 603.x and 604.x prereleases.

This allows compatibility with tools like SwiftLint 0.63+ which require swift-syntax 604.

**Testing:**
- `swift build` ✅
- `swift test` ✅ (62 XCTest + 3 Swift Testing tests pass)

**Note:** There's a new warning about a missing switch case for `.replaceText` in `AssertMacro.swift:443` — this is a new case added in swift-syntax 604 that should be handled in a follow-up.